### PR TITLE
Add the possibility to pass options to the systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ Remove a connection | systemctl disable hide.me@SERVER<br>
 
 SERVER is a server name, group name or an IP address.
 
+Additional commandline options to the `hide.me connect` command run by the
+systemd service can be put into the `OPTIONS=` configuration variable in
+`/opt/hide.me/config`.
+
 Service startup is considered successful when a connection to hide.me server gets completely established. 
 
 ## Contributing

--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+OPTIONS=

--- a/hide.me@.service
+++ b/hide.me@.service
@@ -6,9 +6,10 @@ DefaultDependencies=yes
 
 [Service]
 Type=notify
-ExecStart=/opt/hide.me/hide.me connect %i
+ExecStart=/opt/hide.me/hide.me $OPTIONS connect %i
 WorkingDirectory=/opt/hide.me
 ReadWritePaths=/opt/hide.me /etc
+EnvironmentFile=/opt/hide.me/config
 TimeoutStopSec=30
 Restart=always
 RestartSec=5s

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,9 @@ fi
 
 # Create hide.me directory
 mkdir -p /opt/hide.me/
-cp hide.me CA.pem hide.me@.service /opt/hide.me
+cp hide.me CA.pem hide.me@.service config /opt/hide.me
 chmod +x /opt/hide.me/hide.me
-echo "Binary, CA certificate and SystemD service file installed in /opt/hide.me"
+echo "Binary, CA certificate, SystemD service and config file installed in /opt/hide.me"
 
 # Check for the token
 if [ ! -f /opt/hide.me/accessToken.txt ]; then


### PR DESCRIPTION
Systemd services can be configured to pick up options automatically from so-called environment files.