### PR TITLE
conf output to STDOUT instead of STDERR for classic style redirection

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -75,7 +75,7 @@ func ( c *Configuration ) Store( fileName string ) ( err error ) {
 }
 
 func ( c *Configuration ) Print() {
-	if out, err := yaml.Marshal( c ); err != nil { log.Println( err ) } else { log.Print( string( out ) ) }
+	if out, err := yaml.Marshal( c ); err != nil { log.Println( err ) } else { fmt.Print( string( out ) ) }
 	return
 }
 


### PR DESCRIPTION
hide.me conf output is currently written to the error output (STDERR, 2)

It breaks the classic unix style standard output redirect to file like this: 
`hide.me -options(...) conf > config`

Valid output should be written to STDOUT (1)
Errors should be written to STDERR (2)