### PR TITLE
Change to standard resolv.conf format

### DIFF
--- a/wireguard/dns.go
+++ b/wireguard/dns.go
@@ -20,7 +20,7 @@ func (l *Link) dnsSet( addrs []net.IP ) ( err error ) {
 		}
 	}
 
-	nameServers := "timeout 1\n"																														// Create new content
+	nameServers := "options timeout:1\n"																														// Create new content
 	for _, addr := range addrs { nameServers += "nameserver " + addr.String() + "\n" }
 	
 	if _, err = file.Seek( 0, unix.SEEK_SET ); err != nil { log.Println( "Link: [ERR] Seek in /etc/resolv.conf failed" ); return }						// Seek to start


### PR DESCRIPTION
The line `timeout 1` is invalid or outdated  resolv.conf format, see:  
https://www.man7.org/linux/man-pages/man5/resolv.conf.5.html

This makes some problems with parsing by 3rdparty libs, see:

 https://github.com/cargo-bins/cargo-binstall/issues/1708